### PR TITLE
added appropriate https env variable if HTTP_X_FORWARDED_PROTO is set to...

### DIFF
--- a/root/etc/httpd/conf/httpd.conf
+++ b/root/etc/httpd/conf/httpd.conf
@@ -343,6 +343,13 @@ DocumentRoot "/var/www/html"
     Order allow,deny
     Allow from all
 
+#
+# Since we are accessing through HAProxy, force the server's $_SERVER['HTTPS']
+# variable to be set correctly if coming from HTTPS under the proxy
+
+    SetEnvIfNoCase X-Forwarded-Proto https HTTPS=on
+
+
 </Directory>
 
 #


### PR DESCRIPTION
... https

Fixes #5 

I tested and this appropriately sets the $_SERVER['HTTPS'] variable, which should resolve the problem.   Your earlier issues with this were likely due to the format of the variable name
